### PR TITLE
fixed the fontawesome

### DIFF
--- a/app/views/orders/_index.html.erb
+++ b/app/views/orders/_index.html.erb
@@ -8,7 +8,8 @@
   <div class="sponsor-title">
     <h2 class="txt">您的贊助紀錄</h2>
     <%= link_to user_orders_path( current_user, format: :csv) ,class:"download-icon" do %>
-        <i class="fas fa-cloud-download-alt"></i>
+     <p class="download-icon"><i class="fas fa-cloud-download-alt"></i></p>
+        
     <%end%>
   </div>
 


### PR DESCRIPTION

修正：
csv 下載鍵無法正確顯示的問題

<img width="228" alt="截圖 2021-01-27 上午11 34 04" src="https://user-images.githubusercontent.com/70873399/105939174-9f0fbd80-6093-11eb-96be-d9b9e5edb1c8.png">
